### PR TITLE
Fix compile a error

### DIFF
--- a/src/UtilsParsing.cpp
+++ b/src/UtilsParsing.cpp
@@ -22,6 +22,7 @@ FLARE.  If not, see http://www.gnu.org/licenses/
 #include "Settings.h"
 #include <cstdlib>
 #include <typeinfo>
+#include <math.h>
 
 using namespace std;
 


### PR DESCRIPTION
I am compiling with gcc 4.8.2 here and this error comes up
/home/sb/OSS/flare-engine/src/UtilsParsing.cpp: In function ‘int parse_duration(const string&)’:
/home/sb/OSS/flare-engine/src/UtilsParsing.cpp:58:51: error: could not convert ‘(((float)((int)MAX_FRAMES_PER_SEC \*  val) / 1.0e+3f) + 5.0e-1f)’ from ‘float’ to ‘FPoint’
   val = floor(((val*MAX_FRAMES_PER_SEC) / 1000.f) + 0.5f);

The UtilsParsing.cpp file included the UtilsParsing.h header file, which
includes Utils.h where floor() seems to be defined for FPoint.

So we still need to include the math.h which works for the floats
we're using here.
